### PR TITLE
feat: add Kagi Dictionary page support with flashcard creation

### DIFF
--- a/src/content/dictionary-scraper.ts
+++ b/src/content/dictionary-scraper.ts
@@ -1,0 +1,412 @@
+// Scrape and intercept Kagi Dictionary data
+
+import type {
+  CapturedDictionaryEntry,
+  DictionaryDefinition,
+  DictionarySynonym,
+  DictionaryExample,
+} from "../types/kagi";
+
+export class DictionaryScraper {
+  private currentEntry: Partial<CapturedDictionaryEntry> = {};
+  private observer: MutationObserver | null = null;
+
+  constructor() {
+    this.interceptFetch();
+
+    // Extract from URL and Svelte script tag immediately
+    this.extractFromURL();
+    this.extractFromSvelteData();
+
+    // Use MutationObserver to detect when Svelte hydrates the content
+    this.startMutationObserver();
+
+    // Single unified polling loop for URL and DOM scraping
+    this.startPolling();
+  }
+
+  private startPolling(): void {
+    // Consolidate all periodic checks into one interval
+    setInterval(() => {
+      this.extractFromURL();
+
+      if (!this.currentEntry.definitions?.length) {
+        this.scrapeDefinitionsFromDOM();
+      }
+    }, 500);
+  }
+
+  private extractFromURL(): void {
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+
+    // Try different param names that Kagi might use
+    const word = params.get("word") || params.get("text") || params.get("q");
+    const lang = params.get("lang") || params.get("language") || params.get("from");
+
+    // Only update if we have data and it's different
+    if (word) {
+      const needsUpdate =
+        word !== this.currentEntry.word ||
+        (lang && lang !== this.currentEntry.language);
+
+      if (needsUpdate) {
+        this.currentEntry = {
+          word,
+          language: lang || "auto",
+          timestamp: Date.now(),
+        };
+      }
+    }
+  }
+
+  private extractFromSvelteData(): void {
+    // Kagi uses Svelte with data embedded in a script tag
+    // Look for script tags containing data object
+    const scripts = document.querySelectorAll('script');
+    for (let i = 0; i < scripts.length; i++) {
+      const script = scripts[i];
+      const content = script.textContent || '';
+
+      // Look for patterns like: data: { language: "auto", word: "..." }
+      // or __data = { ... }
+      const patterns = [
+        /data:\s*\{\s*language:\s*["']([^"']+)["'],\s*word:\s*["']([^"']+)["']/,
+        /data:\s*\{\s*word:\s*["']([^"']+)["'],\s*language:\s*["']([^"']+)["']/,
+        /"word":\s*["']([^"']+)["'].*?"language":\s*["']([^"']+)["']/,
+      ];
+
+      for (const pattern of patterns) {
+        const match = content.match(pattern);
+        if (match) {
+          // Different patterns have different group orders
+          let word: string, lang: string;
+          if (pattern.source.indexOf('language') < pattern.source.indexOf('word')) {
+            lang = match[1];
+            word = match[2];
+          } else {
+            word = match[1];
+            lang = match[2];
+          }
+
+          if (word && !this.currentEntry.word) {
+            this.currentEntry.word = word;
+            this.currentEntry.language = lang || "auto";
+            this.currentEntry.timestamp = Date.now();
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  private startMutationObserver(): void {
+    // Watch for DOM changes when Svelte hydrates content
+    this.observer = new MutationObserver((mutations) => {
+      let shouldScrape = false;
+
+      for (const mutation of mutations) {
+        if (mutation.addedNodes.length > 0) {
+          shouldScrape = true;
+          break;
+        }
+      }
+
+      if (shouldScrape && !this.currentEntry.definitions?.length) {
+        // Debounce scraping
+        setTimeout(() => this.scrapeDefinitionsFromDOM(), 100);
+      }
+    });
+
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private interceptFetch(): void {
+    const originalFetch = window.fetch;
+
+    window.fetch = async (...args) => {
+      const response = await originalFetch.apply(window, args);
+
+      // Wrap interception in try-catch to ensure original fetch behavior is not affected
+      try {
+        const clonedResponse = response.clone();
+        const url =
+          typeof args[0] === "string" ? args[0] : (args[0] as Request).url;
+
+        // Handle dictionary-specific API endpoints
+        if (url.includes("/api/dictionary")) {
+          this.handleDictionaryResponse(clonedResponse);
+        }
+      } catch (interceptError) {
+        console.warn('[KagiToAnki] Error in fetch interception (non-fatal):', interceptError);
+      }
+
+      return response;
+    };
+  }
+
+  private async handleDictionaryResponse(response: Response): Promise<void> {
+    try {
+      const data = await response.json();
+
+      // Parse dictionary response - structure may vary, handle flexibly
+      if (data.definitions) {
+        this.currentEntry.definitions = data.definitions;
+      }
+      if (data.synonyms) {
+        this.currentEntry.synonyms = data.synonyms;
+      }
+      if (data.examples) {
+        this.currentEntry.examples = data.examples;
+      }
+      if (data.pronunciation) {
+        this.currentEntry.pronunciation = data.pronunciation;
+      }
+      if (data.etymology) {
+        this.currentEntry.etymology = data.etymology;
+      }
+    } catch (error) {
+      // API parsing failed - DOM scraping will be used as fallback
+      console.warn('[KagiToAnki] Failed to parse dictionary API response, will use DOM scraping:', error);
+    }
+  }
+
+  public getCurrentEntry(): Partial<CapturedDictionaryEntry> {
+    // Before returning, try to scrape from DOM if not already captured
+    if (!this.currentEntry.definitions || this.currentEntry.definitions.length === 0) {
+      this.scrapeDefinitionsFromDOM();
+    }
+
+    if (!this.currentEntry.synonyms || this.currentEntry.synonyms.length === 0) {
+      this.scrapeSynonymsFromDOM();
+    }
+
+    if (!this.currentEntry.examples || this.currentEntry.examples.length === 0) {
+      this.scrapeExamplesFromDOM();
+    }
+
+    if (!this.currentEntry.pronunciation) {
+      this.scrapePronunciationFromDOM();
+    }
+
+    if (!this.currentEntry.etymology) {
+      this.scrapeEtymologyFromDOM();
+    }
+
+    if (!this.currentEntry.notes) {
+      this.scrapeNotesFromDOM();
+    }
+
+    if (!this.currentEntry.relatedWords || this.currentEntry.relatedWords.length === 0) {
+      this.scrapeRelatedWordsFromDOM();
+    }
+
+    return { ...this.currentEntry };
+  }
+
+  private scrapeDefinitionsFromDOM(): void {
+    const definitions: DictionaryDefinition[] = [];
+
+    // Primary meaning - uses #primary-meaning container
+    const primaryDiv = document.getElementById('primary-meaning');
+    if (primaryDiv) {
+      // Get part of speech from the header area (look for noun, verb, etc.)
+      const posEl = primaryDiv.querySelector('span[class*="bg-"]');
+      const partOfSpeech = posEl?.textContent?.trim() || '';
+
+      // Get definition text - only the main p tag, not nested ones
+      const defParagraphs = primaryDiv.querySelectorAll(':scope > div > div p');
+      for (let i = 0; i < defParagraphs.length; i++) {
+        const defText = defParagraphs[i].textContent?.trim();
+        if (defText && defText.length > 10 && !definitions.some(d => d.definition === defText)) {
+          definitions.push({
+            partOfSpeech: i === 0 ? partOfSpeech : '',
+            definition: defText,
+          });
+        }
+      }
+    }
+
+    // Other meanings - uses #other-meanings container
+    const otherDiv = document.getElementById('other-meanings');
+    if (otherDiv) {
+      const defParagraphs = otherDiv.querySelectorAll('p');
+      for (let i = 0; i < defParagraphs.length; i++) {
+        const defText = defParagraphs[i].textContent?.trim();
+        if (defText && defText.length > 10 && !definitions.some(d => d.definition === defText)) {
+          definitions.push({
+            partOfSpeech: '',
+            definition: defText,
+          });
+        }
+      }
+    }
+
+    if (definitions.length > 0) {
+      this.currentEntry.definitions = definitions;
+    }
+  }
+
+  private scrapeSynonymsFromDOM(): void {
+    const synonyms: DictionarySynonym[] = [];
+
+    // Get synonyms from both primary and other meanings sections
+    // Synonyms are button elements within the meaning containers
+    const synonymButtons = document.querySelectorAll(
+      '#primary-meaning button, #other-meanings button'
+    );
+
+    for (let i = 0; i < synonymButtons.length; i++) {
+      const word = synonymButtons[i].textContent?.trim();
+      if (word && word.length > 0 && word.length < 50) {
+        // Avoid duplicates
+        if (!synonyms.some(s => s.word === word)) {
+          synonyms.push({ word });
+        }
+      }
+    }
+
+    if (synonyms.length > 0) {
+      this.currentEntry.synonyms = synonyms;
+    }
+  }
+
+  private scrapeExamplesFromDOM(): void {
+    const examples: DictionaryExample[] = [];
+
+    // Examples are in #examples container with structured list items
+    const examplesDiv = document.getElementById('examples');
+    if (examplesDiv) {
+      // Get example rows from the nested flex container
+      const rows = examplesDiv.querySelectorAll('.flex.flex-col.gap-6 > div');
+
+      for (let i = 0; i < rows.length; i++) {
+        const text = rows[i].querySelector('p')?.textContent?.trim();
+        if (text && text.length > 5) {
+          examples.push({ sentence: text });
+        }
+      }
+    }
+
+    // Fallback: Look for example sentence containers
+    if (examples.length === 0) {
+      const exampleContainers = document.querySelectorAll(
+        '[class*="example"], [class*="usage"], [class*="sentence"], blockquote'
+      );
+
+      for (let i = 0; i < exampleContainers.length; i++) {
+        const sentence = exampleContainers[i].textContent?.trim();
+        if (sentence && sentence.length > 5) {
+          examples.push({ sentence });
+        }
+      }
+    }
+
+    if (examples.length > 0) {
+      this.currentEntry.examples = examples;
+    }
+  }
+
+  private scrapePronunciationFromDOM(): void {
+    // Kagi uses .pronunciation-pill > span for pronunciation
+    const pronEl = document.querySelector('.pronunciation-pill > span');
+    if (pronEl) {
+      const pron = pronEl.textContent?.trim();
+      if (pron && pron.length > 0) {
+        this.currentEntry.pronunciation = pron;
+        return;
+      }
+    }
+
+    // Fallback: Look for IPA or pronunciation elements
+    const pronElements = document.querySelectorAll(
+      '[class*="pronunciation"], [class*="phonetic"], [class*="ipa"], .pron'
+    );
+
+    for (let i = 0; i < pronElements.length; i++) {
+      const el = pronElements[i];
+      const pron = el.textContent?.trim();
+      if (pron && pron.length > 0) {
+        this.currentEntry.pronunciation = pron;
+        break;
+      }
+    }
+  }
+
+  private scrapeEtymologyFromDOM(): void {
+    // Etymology is in #etymology container
+    const etymologyDiv = document.getElementById('etymology');
+    if (etymologyDiv) {
+      const text = etymologyDiv.querySelector('p')?.textContent?.trim();
+      if (text && text.length > 0) {
+        this.currentEntry.etymology = text;
+      }
+    }
+  }
+
+  private scrapeNotesFromDOM(): void {
+    // Notes section - look for #notes container or similar
+    const notesDiv = document.getElementById('notes');
+    if (notesDiv) {
+      const paragraphs = notesDiv.querySelectorAll('p');
+      const noteTexts: string[] = [];
+      for (let i = 0; i < paragraphs.length; i++) {
+        const text = paragraphs[i].textContent?.trim();
+        if (text && text.length > 0) {
+          noteTexts.push(text);
+        }
+      }
+      if (noteTexts.length > 0) {
+        this.currentEntry.notes = noteTexts.join('\n');
+      }
+    }
+  }
+
+  private scrapeRelatedWordsFromDOM(): void {
+    const relatedWords: string[] = [];
+
+    // Look for related-words container
+    const relatedDiv = document.getElementById('related-words');
+    if (relatedDiv) {
+      const buttons = relatedDiv.querySelectorAll('button');
+      for (let i = 0; i < buttons.length; i++) {
+        const word = buttons[i].textContent?.trim();
+        if (word && word.length > 0 && word.length < 50) {
+          if (!relatedWords.includes(word)) {
+            relatedWords.push(word);
+          }
+        }
+      }
+    }
+
+    if (relatedWords.length > 0) {
+      this.currentEntry.relatedWords = relatedWords;
+    }
+  }
+
+  public hasCompleteEntry(): boolean {
+    // For dictionary, we only require word + language to show the button
+    // Definitions are scraped from client-side rendered content and may not be available immediately
+    // The card will be created with whatever data we have at save time
+    const hasBasics = !!(
+      this.currentEntry.word &&
+      this.currentEntry.language
+    );
+
+    // Still try to scrape definitions in the background
+    if (hasBasics && (!this.currentEntry.definitions || this.currentEntry.definitions.length === 0)) {
+      this.scrapeDefinitionsFromDOM();
+    }
+
+    return hasBasics;
+  }
+
+  public reset(): void {
+    this.currentEntry = {
+      timestamp: Date.now(),
+    };
+  }
+}

--- a/src/content/dictionary-scraper.ts
+++ b/src/content/dictionary-scraper.ts
@@ -10,6 +10,7 @@ import type {
 export class DictionaryScraper {
   private currentEntry: Partial<CapturedDictionaryEntry> = {};
   private observer: MutationObserver | null = null;
+  private pollingInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor() {
     this.interceptFetch();
@@ -27,7 +28,7 @@ export class DictionaryScraper {
 
   private startPolling(): void {
     // Consolidate all periodic checks into one interval
-    setInterval(() => {
+    this.pollingInterval = setInterval(() => {
       this.extractFromURL();
 
       if (!this.currentEntry.definitions?.length) {
@@ -408,5 +409,17 @@ export class DictionaryScraper {
     this.currentEntry = {
       timestamp: Date.now(),
     };
+  }
+
+  public destroy(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = null;
+    }
+    this.currentEntry = {};
   }
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,88 +1,66 @@
 // Main content script
 
 import { KagiScraper } from './kagi-scraper';
+import { DictionaryScraper } from './dictionary-scraper';
 import { UIInjector } from './ui-injector';
 import { fetchAudioAsBase64, generateAudioFilename } from '../utils/audio-handler';
 import { getSettings } from '../utils/storage';
-import type { CapturedTranslation } from '../types/kagi';
+import type { CapturedTranslation, CapturedDictionaryEntry } from '../types/kagi';
 
+// Detect page type based on URL path
+function getPageType(): 'translate' | 'dictionary' {
+  const pathname = window.location.pathname;
+  if (pathname.startsWith('/dictionary')) {
+    return 'dictionary';
+  }
+  return 'translate';
+}
 
-const scraper = new KagiScraper();
+// Detect selected voice from Kagi UI
+function detectSelectedVoice(): string {
+  const selectedVoiceBtn = document.querySelector('button[role="option"][aria-selected="true"]');
+  if (selectedVoiceBtn) {
+    const voiceText = selectedVoiceBtn.textContent || '';
+    const voiceMatch = voiceText.match(/^(Alloy|Ash|Ballad|Coral|Echo|Fable|Onyx|Nova|Sage|Shimmer|Verse)/i);
+    if (voiceMatch) {
+      return voiceMatch[1].toLowerCase();
+    }
+  }
+  return 'sage'; // default fallback
+}
+
+// Initialize scrapers based on page type
+const pageType = getPageType();
+const translationScraper = pageType === 'translate' ? new KagiScraper() : null;
+const dictionaryScraper = pageType === 'dictionary' ? new DictionaryScraper() : null;
 const ui = new UIInjector();
 
-// Monitor for translation completion
+// Monitor for completion based on page type
 let checkInterval = setInterval(() => {
-  if (scraper.hasCompleteTranslation()) {
-    ui.showButton();
+  if (pageType === 'dictionary') {
+    if (dictionaryScraper?.hasCompleteEntry()) {
+      ui.showButton();
+    }
+  } else {
+    if (translationScraper?.hasCompleteTranslation()) {
+      ui.showButton();
+    }
   }
 }, 500);
 
 // Handle save button click
 ui.onSave(async () => {
   ui.setLoading(true);
-  
+
   try {
-    const translation = scraper.getCurrentTranslation();
-    
-    if (!scraper.hasCompleteTranslation()) {
-      throw new Error('Translation data is incomplete');
-    }
-    
-    // Fetch audio if enabled in settings
     const settings = await getSettings();
-    
-    if (settings.includeAudio) {
-      // Detect currently selected voice from Kagi UI
-      const selectedVoiceBtn = document.querySelector('button[role="option"][aria-selected="true"]');
-      let voice = 'sage'; // default fallback
-      
-      if (selectedVoiceBtn) {
-        const voiceText = selectedVoiceBtn.textContent || '';
-        const voiceMatch = voiceText.match(/^(Alloy|Ash|Ballad|Coral|Echo|Fable|Onyx|Nova|Sage|Shimmer|Verse)/i);
-        if (voiceMatch) {
-          voice = voiceMatch[1].toLowerCase();
-        }
-      }
-      
-      const audioResult = await fetchAudioAsBase64(
-        translation.targetText!,
-        translation.targetLang!,
-        voice
-      );
-      
-      if (audioResult) {
-        translation.audioData = audioResult.data;
-        translation.audioFilename = generateAudioFilename(
-          translation.sourceLang!,
-          translation.targetLang!,
-          audioResult.mimeType
-        );
-      }
-    }
-    
-    // Send to background script to save to Anki
-    const response = await chrome.runtime.sendMessage({
-      type: 'SAVE_TO_ANKI',
-      data: translation as CapturedTranslation,
-    });
-    
-    if (response.success) {
-      // Build success message with details
-      const parts = ['Saved to Anki!'];
-      const insightCount = translation.insights?.length || 0;
-      const altCount = translation.alternatives?.length || 0;
-      
-      const details = [];
-      if (insightCount > 0) details.push(`${insightCount} word insight${insightCount > 1 ? 's' : ''}`);
-      if (altCount > 0) details.push(`${altCount} alternative${altCount > 1 ? 's' : ''}`);
-      
-      if (details.length > 0) {
-        parts.push(details.join(', '));
-      }
-      
-      ui.showToast(parts.join(' • '), 'success');
+
+    if (pageType === 'dictionary') {
+      // Handle dictionary save
+      await handleDictionarySave(settings);
     } else {
-      throw new Error(response.error || 'Unknown error');
+      // Handle translation save
+      await handleTranslationSave(settings);
     }
   } catch (error) {
     ui.showToast(`Failed to save: ${error}`, 'error');
@@ -91,13 +69,132 @@ ui.onSave(async () => {
   }
 });
 
+async function handleTranslationSave(settings: Awaited<ReturnType<typeof getSettings>>) {
+  if (!translationScraper) {
+    throw new Error('Translation scraper not available. Please refresh the page.');
+  }
+
+  const translation = translationScraper.getCurrentTranslation();
+
+  if (!translationScraper.hasCompleteTranslation()) {
+    throw new Error('Translation data is incomplete');
+  }
+
+  // Fetch audio if enabled in settings
+  if (settings.includeAudio) {
+    const voice = detectSelectedVoice();
+
+    const audioResult = await fetchAudioAsBase64(
+      translation.targetText!,
+      translation.targetLang!,
+      voice
+    );
+
+    if (audioResult) {
+      translation.audioData = audioResult.data;
+      translation.audioFilename = generateAudioFilename(
+        translation.sourceLang!,
+        translation.targetLang!,
+        audioResult.mimeType
+      );
+    }
+  }
+
+  // Send to background script to save to Anki
+  const response = await chrome.runtime.sendMessage({
+    type: 'SAVE_TO_ANKI',
+    data: translation as CapturedTranslation,
+  });
+
+  if (response.success) {
+    // Build success message with details
+    const parts = ['Saved to Anki!'];
+    const insightCount = translation.insights?.length || 0;
+    const altCount = translation.alternatives?.length || 0;
+
+    const details = [];
+    if (insightCount > 0) details.push(`${insightCount} word insight${insightCount > 1 ? 's' : ''}`);
+    if (altCount > 0) details.push(`${altCount} alternative${altCount > 1 ? 's' : ''}`);
+
+    if (details.length > 0) {
+      parts.push(details.join(', '));
+    }
+
+    ui.showToast(parts.join(' • '), 'success');
+  } else {
+    throw new Error(response.error || 'Unknown error');
+  }
+}
+
+async function handleDictionarySave(settings: Awaited<ReturnType<typeof getSettings>>) {
+  if (!dictionaryScraper) {
+    throw new Error('Dictionary scraper not available. Please refresh the page.');
+  }
+
+  const entry = dictionaryScraper.getCurrentEntry();
+
+  if (!dictionaryScraper.hasCompleteEntry()) {
+    throw new Error('Dictionary entry is incomplete');
+  }
+
+  // Fetch audio if enabled in settings
+  if (settings.includeAudio && entry.word && entry.language) {
+    const voice = detectSelectedVoice();
+
+    const audioResult = await fetchAudioAsBase64(
+      entry.word,
+      entry.language,
+      voice
+    );
+
+    if (audioResult) {
+      entry.audioData = audioResult.data;
+      entry.audioFilename = generateAudioFilename(
+        entry.language,
+        entry.language,
+        audioResult.mimeType
+      );
+    }
+  }
+
+  // Send to background script to save to Anki
+  const response = await chrome.runtime.sendMessage({
+    type: 'SAVE_DICTIONARY_TO_ANKI',
+    data: entry as CapturedDictionaryEntry,
+  });
+
+  if (response.success) {
+    const defCount = entry.definitions?.length || 0;
+    const synCount = entry.synonyms?.length || 0;
+
+    const details = [];
+    if (defCount > 0) details.push(`${defCount} definition${defCount > 1 ? 's' : ''}`);
+    if (synCount > 0) details.push(`${synCount} synonym${synCount > 1 ? 's' : ''}`);
+
+    const message = details.length > 0
+      ? `Saved to Anki! • ${details.join(', ')}`
+      : 'Saved to Anki!';
+
+    ui.showToast(message, 'success');
+  } else {
+    throw new Error(response.error || 'Unknown error');
+  }
+}
+
 // Monitor URL changes (for SPA navigation)
 let lastURL = window.location.href;
 setInterval(() => {
   const currentURL = window.location.href;
   if (currentURL !== lastURL) {
     lastURL = currentURL;
-    scraper.reset();
+
+    // Reset appropriate scraper
+    if (pageType === 'dictionary') {
+      dictionaryScraper?.reset();
+    } else {
+      translationScraper?.reset();
+    }
+
     ui.hideButton();
   }
 }, 500);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -33,7 +33,7 @@ function detectSelectedVoice(): string {
 const pageType = getPageType();
 const translationScraper = pageType === 'translate' ? new KagiScraper() : null;
 const dictionaryScraper = pageType === 'dictionary' ? new DictionaryScraper() : null;
-const ui = new UIInjector();
+const ui = new UIInjector(pageType);
 
 // Monitor for completion based on page type
 let checkInterval = setInterval(() => {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -43,3 +43,34 @@
 .kagi-to-anki-toast.error {
     background: #5352FF;
 }
+
+/* Floating button for dictionary page */
+.kagi-to-anki-floating-btn {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    padding: 12px 20px;
+    background: #5352FF;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(83, 82, 255, 0.4);
+    z-index: 10000;
+    transition: all 0.2s ease;
+}
+
+.kagi-to-anki-floating-btn:hover {
+    background: #4342EE;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(83, 82, 255, 0.5);
+}
+
+.kagi-to-anki-floating-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}

--- a/src/content/ui-injector.ts
+++ b/src/content/ui-injector.ts
@@ -176,4 +176,17 @@ export class UIInjector {
       this.button.innerHTML = text;
     }
   }
+
+  public destroy(): void {
+    this.stopObserving();
+    if (this.button) {
+      this.button.remove();
+      this.button = null;
+    }
+    if (this.toast) {
+      this.toast.remove();
+      this.toast = null;
+    }
+    this.onSaveCallback = null;
+  }
 }

--- a/src/content/ui-injector.ts
+++ b/src/content/ui-injector.ts
@@ -12,10 +12,10 @@ export class UIInjector {
   }
 
   private injectButton(): void {
-    const tryInject = () => {
+    const tryInjectToolbar = (): boolean => {
       if (this.button) return true; // Already injected
 
-      // Look for the bottom toolbar that contains copy/download buttons
+      // Look for the bottom toolbar that contains copy/download buttons (translation page)
       const toolbar = document.querySelector(".fixed.z-\\[25\\]");
 
       if (toolbar) {
@@ -55,24 +55,41 @@ export class UIInjector {
           toolbar.appendChild(buttonWrapper);
         }
 
-        // Stop observing once button is injected
-        if (this.observer) {
-          this.observer.disconnect();
-          this.observer = null;
-        }
-        
+        this.stopObserving();
         return true;
       }
-      
+
       return false;
     };
 
-    // Try immediate injection
-    if (tryInject()) return;
+    const injectFloatingButton = (): void => {
+      if (this.button) return; // Already injected
+
+      // Create a floating button for pages without the toolbar (e.g., dictionary page)
+      this.button = document.createElement("button");
+      this.button.id = "kagi-to-anki-button";
+      this.button.type = "button";
+      this.button.className = "kagi-to-anki-floating-btn";
+      this.button.setAttribute("aria-label", "Save to Anki");
+      this.button.innerHTML = "Save to Anki";
+      this.button.style.display = "none"; // Hidden until entry is ready
+
+      this.button.addEventListener("click", () => {
+        if (this.onSaveCallback) {
+          this.onSaveCallback();
+        }
+      });
+
+      document.body.appendChild(this.button);
+      this.stopObserving();
+    };
+
+    // Try immediate toolbar injection
+    if (tryInjectToolbar()) return;
 
     // Use MutationObserver to watch for toolbar appearance
     this.observer = new MutationObserver(() => {
-      tryInject();
+      tryInjectToolbar();
     });
 
     // Observe the entire document body for changes
@@ -81,8 +98,19 @@ export class UIInjector {
       subtree: true,
     });
 
-    // Fallback: also try after short delay in case observer misses it
-    setTimeout(() => tryInject(), 1000);
+    // After 2 seconds, if toolbar not found, create floating button
+    setTimeout(() => {
+      if (!this.button) {
+        injectFloatingButton();
+      }
+    }, 2000);
+  }
+
+  private stopObserving(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
   }
 
   private injectToastContainer(): void {

--- a/src/types/kagi.ts
+++ b/src/types/kagi.ts
@@ -1,4 +1,4 @@
-// Type definitions for Kagi Translate API responses
+// Type definitions for Kagi Translate and Dictionary API responses
 
 export interface KagiWordInsight {
   id: string;
@@ -48,6 +48,42 @@ export interface CapturedTranslation {
 
   // From text-alignments API
   alignments?: KagiTextAlignment;
+
+  // Audio data (base64 encoded)
+  audioData?: string;
+  audioFilename?: string;
+
+  // Metadata
+  timestamp: number;
+}
+
+// Dictionary-specific types
+export interface DictionaryDefinition {
+  partOfSpeech: string;
+  definition: string;
+  examples?: string[];
+}
+
+export interface DictionarySynonym {
+  word: string;
+  partOfSpeech?: string;
+}
+
+export interface DictionaryExample {
+  sentence: string;
+  translation?: string;
+}
+
+export interface CapturedDictionaryEntry {
+  word: string;
+  language: string;
+  pronunciation?: string;
+  definitions: DictionaryDefinition[];
+  synonyms?: DictionarySynonym[];
+  examples?: DictionaryExample[];
+  etymology?: string;
+  notes?: string;
+  relatedWords?: string[];
 
   // Audio data (base64 encoded)
   audioData?: string;


### PR DESCRIPTION
## Add Dictionary Support for Kagi Dictionary Pages

### Summary
This PR adds comprehensive support for capturing dictionary entries from Kagi Dictionary pages and saving them directly to Anki as structured flashcards.

### Changes

#### New Features
- **DictionaryScraper class** - Extracts structured data from Kagi Dictionary pages including:
  - Definitions with parts of speech
  - Pronunciation guides
  - Usage examples
  - Etymology
  - Synonyms
  - Usage notes
  - Related words

- **Floating "Save to Anki" button** - Appears on dictionary pages for one-click card creation

- **Dictionary card formatter** - Creates well-organized Anki cards with dedicated sections:
  - Primary Meaning
  - Other Meanings
  - Notes
  - Examples
  - Etymology
  - Related Words

#### Code Improvements
- Extracted shared `saveNoteToAnki` helper function to reduce code duplication in the background script
- Added `SAVE_DICTIONARY_TO_ANKI` message handler
- Consolidated polling intervals in the dictionary scraper for cleaner implementation

#### Type Definitions
- Added dictionary-specific types:
  - `CapturedDictionaryEntry`
  - `DictionaryDefinition`
  - Related supporting types

### Testing
- [x] Tested scraping various dictionary entries on Kagi Dictionary
- [x] Verified card formatting in Anki
- [x] Confirmed button appears/disappears appropriately on dictionary pages